### PR TITLE
Handle circular dependencies when doing interop loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,12 @@ export do
 end
 
 ### foo_wrapper.rb
-export do
-  # Load the 'foo' constant from foo.rb
-  foo = import './foo'
+# Load the 'foo' constant from foo.rb
+foo = import './foo'
 
-  def wrapper
-    foo
-  end
+export do
+  wrapper = lambda { foo }
+  wrapper
 end
 
 ### test.rb
@@ -80,7 +79,7 @@ foo = import './foo_wrapper'
 # compatible with external globals-style ruby modules
 assert = import('test/unit/assertions')['Test::Unit::Assertions']
 
-assert.assert_equal(foo(), 'foo')
+assert.assert_equal(foo.call(), 'foo')
 # No global namespace pollution \o/
 assert.assert_equal(defined? Test, nil)
 ```

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -29,7 +29,11 @@ module Loader
     end
 
     @path = File.expand_path(raw)
-    require @path
+    if !@cache.include?(@path)
+      id = @path.end_with?('.rb') ? @path : "#{@path}.rb"
+      Kernel.load(id, true)
+    end
+
     result = @cache[@path]
     @path = prev
     result

--- a/test/fixtures/reverse.rb
+++ b/test/fixtures/reverse.rb
@@ -1,9 +1,11 @@
 export do
-  def reverse(str, result='')
+  reverse = lambda do |str, result=''|
     if str.length == 0
       result
     else
-      reverse(str[1..-1], str[0] + result)
+      reverse.call(str[1..-1], str[0] + result)
     end
   end
+
+  reverse
 end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -8,6 +8,6 @@ RSpec.describe Loader do
 
   it "#import" do
     reverse = Loader.import('./reverse')
-    expect(reverse('123')).to eq '321'
+    expect(reverse.call('123')).to eq '321'
   end
 end


### PR DESCRIPTION
Right now if global-style ruby modules reference one another there's a circular dependencies issue that causes an infinite loop. We should detect circular dependencies and handle them gracefully.