### PR TITLE
Test on multiple versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 1.9.3
+  - jruby-19mode
 script:
   - bundle exec rspec --color --pattern test/**/*_test.rb
   - ./bin/modules run example/main.rb


### PR DESCRIPTION
Ideally we'd run all of our tests on 1.9, 2.2, jruby, and latest rubinius.