### PR TITLE
Prefer local modules when resolving ambiguous module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ assert.assert_equal(foo.call(), 'foo')
 assert.assert_equal(defined? Test, nil)
 ```
 
+### Resolution algorithm
+
+When `import('bar/baz')` is called from /home/lambdabaa/foo, `modules`
+will build /home/lambdabaa/foo/bar/baz (currently by composing
+`File.expand_path` and `File.join`) and check whether this file exists.
+If it does, `modules` will assume this is a local import. Otherwise,
+it will assume `bar/baz` isn't a locally defined module and will try
+`require('bar/baz')`.
+
 ### Wat?
 
 I'm glad you asked! Under the hood we load code into the modules cache


### PR DESCRIPTION
Right now if a module identifier doesn't begin with `'.'` or `'/'` we consider it a global package for interop. We should check to see if a relative local module exists first before failing over to global lookup.