### PR TITLE
Ruby v2.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
+  - 2.2.0
   - 1.9.3
   - jruby-19mode
 script:
   - bundle exec rspec --color --pattern test/**/*_test.rb
   - ./bin/modules run example/main.rb
+  - ruby test/interop_cycles.rb

--- a/test/interop_cycles.rb
+++ b/test/interop_cycles.rb
@@ -1,0 +1,12 @@
+# Not an rspec test case. This simply makes sure that we
+# can use the interop loader to require an external package
+# with circular dependencies. The only example I could find
+# was 'optparse' and rspec loads that package so this test
+# is only useful when run outside of rspec (ie ruby test/interop_cycles.rb).
+
+require_relative '../lib/interop'
+
+# This goes into an infinite loop without cycle detection.
+OptionParser = Interop.import('optparse')['OptionParser']
+assert = Interop.import('test/unit/assertions')['Test::Unit::Assertions']
+assert.assert_equal(OptionParser.class, Class)


### PR DESCRIPTION
The tests currently pass, but running `./bin/modules run example/main.rb` hangs on ruby 2.2.