### PR TITLE
Dynamic local module loads can fail because of the resolution strategy

### DIFF
--- a/bin/modules
+++ b/bin/modules
@@ -24,4 +24,6 @@ def main
   Modules.main(ARGV[0], ARGV[1..-1], options)
 end
 
-main()
+if __FILE__ == $0
+  main
+end

--- a/lib/modules/callsite.rb
+++ b/lib/modules/callsite.rb
@@ -1,0 +1,9 @@
+module Callsite
+  # Prefer caller_locations since it's faster, but failover to caller
+  # since caller_locations was only introduced in v2.0.0.
+  def self.resolve(idx=1)
+    defined?(caller_locations) ?
+      caller_locations[idx + 1].absolute_path :
+      caller[idx + 1].split(':').first
+  end
+end


### PR DESCRIPTION
Right now the module loader only holds a single path variable that works in the following way

1. First the path gets set to the current working directory.
2. Whenever a module calls import on another, the path gets updated to the module being imported until the import is finished, at which point the path gets reset

This plays out as a depth first search which works as expected for calls to `import` made immediately when `Kernel#load` is called. However, this can fail if `import` is called later on since the path placeholder won't be pointing to the file calling `import`.